### PR TITLE
カレンダーのプログラム(JavaScript)

### DIFF
--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -14,8 +14,8 @@ const buildCalendarBody = (year, month) => {
   const saturday = 6;
   const firstDate = new Date(year, month - 1, 1);
   const lastDate = new Date(year, month, 0);
-  const rows = [];
   let datesPerWeek = new Array(firstDate.getDay()).fill("  ");
+  const rows = [];
   [...Array(lastDate.getDate())]
     .map((_, i) => new Date(year, month - 1, i + 1))
     .forEach((date) => {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -31,7 +31,7 @@ const buildCalendarBody = (year, month) => {
   }
   const totalRows = 6;
   const rowsOfEmptyString = Array(totalRows - rowsOfDateString.length).fill("");
-  return rowsOfDateString.concat(rowsOfEmptyString).join("\n");
+  return [...rowsOfDateString, ...rowsOfEmptyString].join("\n");
 };
 
 if (import.meta.filename === process.argv[1]) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -23,10 +23,10 @@ const buildCalendarBody = (year, month) => {
     ),
   ];
 
-  const dayCountsPerWeek = 7;
+  const dayCountPerRow = 7;
   const rows = [];
   while (dateStrings.length) {
-    const dateStringsPerRow = dateStrings.splice(0, dayCountsPerWeek);
+    const dateStringsPerRow = dateStrings.splice(0, dayCountPerRow);
     rows.push(dateStringsPerRow.join(" "));
   }
   const totalRows = 6;

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -6,11 +6,11 @@ export const buildCalendar = (year, month) => {
   return [
     `      ${month}月 ${year}`,
     "日 月 火 水 木 金 土",
-    ...arrangeDates(year, month),
+    ...buildCalendarBody(year, month),
   ].join("\n");
 };
 
-const arrangeDates = (year, month) => {
+const buildCalendarBody = (year, month) => {
   const saturDay = 6;
   const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
   const last_date = new Date(year, month, 0).getDate();

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import parseArgs from "minimist";
+
+export const cal = (year, month) => {
+  return [
+    `      ${month}月 ${year}`,
+    "日 月 火 水 木 金 土",
+    ...arrangeDates(year, month),
+  ].join("\n");
+};
+
+const arrangeDates = (year, month) => {
+  const saturDay = 6;
+  const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
+  const last_date = new Date(year, month, 0).getDate();
+  let rows = [];
+  let row = new Array(firstDayOfWeek).fill("  ");
+  let dayOfWeek = firstDayOfWeek;
+  for (let i = 1; i <= last_date; i++) {
+    row.push(String(i).padStart(2));
+    if (dayOfWeek === saturDay || i === last_date) {
+      rows.push(row.join(" "));
+      row = [];
+      dayOfWeek = 0;
+    } else {
+      dayOfWeek++;
+    }
+  }
+  const totalRows = 6;
+  if (rows.length < totalRows) {
+    rows.push("");
+  }
+  return rows;
+};
+
+if (import.meta.filename === process.argv[1]) {
+  const today = new Date();
+  const options = {
+    default: {
+      y: today.getFullYear(),
+      m: today.getMonth() + 1,
+    },
+  };
+  const params = parseArgs(process.argv.slice(2), options);
+  console.log(cal(params.y, params.m));
+}

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -6,7 +6,7 @@ export const buildCalendar = (year, month) => {
   return [
     `      ${month}月 ${year}`,
     "日 月 火 水 木 金 土",
-    ...buildCalendarBody(year, month),
+    buildCalendarBody(year, month),
   ].join("\n");
 };
 
@@ -27,7 +27,7 @@ const buildCalendarBody = (year, month) => {
     rows.push(dateStringsPerRow.join(" "));
   }
   const totalRows = 6;
-  return rows.concat(Array(totalRows - rows.length).fill(""));
+  return rows.concat(Array(totalRows - rows.length).fill("")).join("\n");
 };
 
 if (import.meta.filename === process.argv[1]) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -25,8 +25,8 @@ const buildCalendarBody = (year, month) => {
 
   const dayCountPerRow = 7;
   const rows = [];
-  while (dateStrings.length > 0) {
-    const dateStringsPerRow = dateStrings.splice(0, dayCountPerRow);
+  for (let start = 0; start < dateStrings.length; start += dayCountPerRow) {
+    const dateStringsPerRow = dateStrings.slice(start, start + dayCountPerRow);
     rows.push(dateStringsPerRow.join(" "));
   }
   const totalRows = 6;

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -30,7 +30,8 @@ const buildCalendarBody = (year, month) => {
     rows.push(dateStringsPerRow.join(" "));
   }
   const totalRows = 6;
-  return rows.concat(Array(totalRows - rows.length).fill("")).join("\n");
+  const rowsOfEmptyString = Array(totalRows - rows.length).fill("");
+  return rows.concat(rowsOfEmptyString).join("\n");
 };
 
 if (import.meta.filename === process.argv[1]) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -14,7 +14,7 @@ const buildCalendarBody = (year, month) => {
   const saturday = 6;
   const firstDate = new Date(year, month - 1, 1);
   const lastDate = new Date(year, month, 0);
-  let rows = [];
+  const rows = [];
   let datesPerWeek = new Array(firstDate.getDay()).fill("  ");
   [...Array(lastDate.getDate())]
     .map((_, i) => new Date(year, month - 1, i + 1))

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import parseArgs from "minimist";
+import minimist from "minimist";
 
 export const cal = (year, month) => {
   return [
@@ -40,6 +40,6 @@ if (import.meta.filename === process.argv[1]) {
       m: today.getMonth() + 1,
     },
   };
-  const params = parseArgs(process.argv.slice(2), options);
+  const params = minimist(process.argv.slice(2), options);
   console.log(cal(params.y, params.m));
 }

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -26,8 +26,7 @@ const buildCalendarBody = (year, month) => {
       }
     });
   const totalRows = 6;
-  const emptyRows = new Array(totalRows - rows.length).fill("");
-  return rows.concat(emptyRows);
+  return rows.concat(new Array(totalRows - rows.length).fill(""));
 };
 
 if (import.meta.filename === process.argv[1]) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -4,10 +4,13 @@ import minimist from "minimist";
 
 export const buildCalendar = (year, month) => {
   return [
-    `      ${month}月 ${year}`,
-    "日 月 火 水 木 金 土",
+    buildCalendarHeader(year, month),
     buildCalendarBody(year, month),
   ].join("\n");
+};
+
+const buildCalendarHeader = (year, month) => {
+  return [`      ${month}月 ${year}`, "日 月 火 水 木 金 土"].join("\n");
 };
 
 const buildCalendarBody = (year, month) => {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -24,14 +24,14 @@ const buildCalendarBody = (year, month) => {
   ];
 
   const dayCountPerRow = 7;
-  const rows = [];
+  const rowsOfDateString = [];
   for (let start = 0; start < dateStrings.length; start += dayCountPerRow) {
     const dateStringsPerRow = dateStrings.slice(start, start + dayCountPerRow);
-    rows.push(dateStringsPerRow.join(" "));
+    rowsOfDateString.push(dateStringsPerRow.join(" "));
   }
   const totalRows = 6;
-  const rowsOfEmptyString = Array(totalRows - rows.length).fill("");
-  return rows.concat(rowsOfEmptyString).join("\n");
+  const rowsOfEmptyString = Array(totalRows - rowsOfDateString.length).fill("");
+  return rowsOfDateString.concat(rowsOfEmptyString).join("\n");
 };
 
 if (import.meta.filename === process.argv[1]) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -12,21 +12,19 @@ export const buildCalendar = (year, month) => {
 
 const buildCalendarBody = (year, month) => {
   const saturday = 6;
-  const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
-  const lastDate = new Date(year, month, 0).getDate();
+  const firstDate = new Date(year, month - 1, 1);
+  const lastDate = new Date(year, month, 0);
   let rows = [];
-  let row = new Array(firstDayOfWeek).fill("  ");
-  let dayOfWeek = firstDayOfWeek;
-  for (let i = 1; i <= lastDate; i++) {
-    row.push(String(i).padStart(2));
-    if (dayOfWeek === saturday || i === lastDate) {
-      rows.push(row.join(" "));
-      row = [];
-      dayOfWeek = 0;
-    } else {
-      dayOfWeek++;
-    }
-  }
+  let row = new Array(firstDate.getDay()).fill("  ");
+  [...Array(lastDate.getDate())]
+    .map((_, i) => new Date(year, month - 1, i + 1))
+    .forEach((date) => {
+      row.push(String(date.getDate()).padStart(2));
+      if (date.getDay() === saturday || date.getDate() === lastDate.getDate()) {
+        rows.push(row.join(" "));
+        row = [];
+      }
+    });
   const totalRows = 6;
   const emptyRows = new Array(totalRows - rows.length).fill("");
   return rows.concat(emptyRows);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -15,14 +15,14 @@ const buildCalendarBody = (year, month) => {
   const firstDate = new Date(year, month - 1, 1);
   const lastDate = new Date(year, month, 0);
   let rows = [];
-  let row = new Array(firstDate.getDay()).fill("  ");
+  let datesPerWeek = new Array(firstDate.getDay()).fill("  ");
   [...Array(lastDate.getDate())]
     .map((_, i) => new Date(year, month - 1, i + 1))
     .forEach((date) => {
-      row.push(String(date.getDate()).padStart(2));
+      datesPerWeek.push(String(date.getDate()).padStart(2));
       if (date.getDay() === saturday || date.getDate() === lastDate.getDate()) {
-        rows.push(row.join(" "));
-        row = [];
+        rows.push(datesPerWeek.join(" "));
+        datesPerWeek = [];
       }
     });
   const totalRows = 6;

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -11,20 +11,21 @@ export const buildCalendar = (year, month) => {
 };
 
 const buildCalendarBody = (year, month) => {
-  const saturday = 6;
   const firstDate = new Date(year, month - 1, 1);
   const lastDate = new Date(year, month, 0);
-  let dateStringsPerRow = Array(firstDate.getDay()).fill("  ");
+  const dateStrings = [
+    ...Array(firstDate.getDay()).fill("  "),
+    ...Array.from({ length: lastDate.getDate() }, (_, i) =>
+      String(i + 1).padStart(2),
+    ),
+  ];
+
+  const dayCountsPerWeek = 7;
   const rows = [];
-  [...Array(lastDate.getDate())]
-    .map((_, i) => new Date(year, month - 1, i + 1))
-    .forEach((date) => {
-      dateStringsPerRow.push(String(date.getDate()).padStart(2));
-      if (date.getDay() === saturday || date.getDate() === lastDate.getDate()) {
-        rows.push(dateStringsPerRow.join(" "));
-        dateStringsPerRow = [];
-      }
-    });
+  while (dateStrings.length) {
+    const dateStringsPerRow = dateStrings.splice(0, dayCountsPerWeek);
+    rows.push(dateStringsPerRow.join(" "));
+  }
   const totalRows = 6;
   return rows.concat(Array(totalRows - rows.length).fill(""));
 };

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -11,7 +11,7 @@ export const buildCalendar = (year, month) => {
 };
 
 const buildCalendarBody = (year, month) => {
-  const saturDay = 6;
+  const saturday = 6;
   const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
   const last_date = new Date(year, month, 0).getDate();
   let rows = [];
@@ -19,7 +19,7 @@ const buildCalendarBody = (year, month) => {
   let dayOfWeek = firstDayOfWeek;
   for (let i = 1; i <= last_date; i++) {
     row.push(String(i).padStart(2));
-    if (dayOfWeek === saturDay || i === last_date) {
+    if (dayOfWeek === saturday || i === last_date) {
       rows.push(row.join(" "));
       row = [];
       dayOfWeek = 0;

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -14,7 +14,7 @@ const buildCalendarBody = (year, month) => {
   const saturday = 6;
   const firstDate = new Date(year, month - 1, 1);
   const lastDate = new Date(year, month, 0);
-  let datesPerWeek = new Array(firstDate.getDay()).fill("  ");
+  let datesPerWeek = Array(firstDate.getDay()).fill("  ");
   const rows = [];
   [...Array(lastDate.getDate())]
     .map((_, i) => new Date(year, month - 1, i + 1))
@@ -26,7 +26,7 @@ const buildCalendarBody = (year, month) => {
       }
     });
   const totalRows = 6;
-  return rows.concat(new Array(totalRows - rows.length).fill(""));
+  return rows.concat(Array(totalRows - rows.length).fill(""));
 };
 
 if (import.meta.filename === process.argv[1]) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -2,7 +2,7 @@
 
 import minimist from "minimist";
 
-export const cal = (year, month) => {
+export const buildCalendar = (year, month) => {
   return [
     `      ${month}月 ${year}`,
     "日 月 火 水 木 金 土",
@@ -40,5 +40,5 @@ if (import.meta.filename === process.argv[1]) {
       m: today.getMonth() + 1,
     },
   });
-  console.log(cal(params.y, params.m));
+  console.log(buildCalendar(params.y, params.m));
 }

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -13,13 +13,13 @@ export const buildCalendar = (year, month) => {
 const buildCalendarBody = (year, month) => {
   const saturday = 6;
   const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
-  const last_date = new Date(year, month, 0).getDate();
+  const lastDate = new Date(year, month, 0).getDate();
   let rows = [];
   let row = new Array(firstDayOfWeek).fill("  ");
   let dayOfWeek = firstDayOfWeek;
-  for (let i = 1; i <= last_date; i++) {
+  for (let i = 1; i <= lastDate; i++) {
     row.push(String(i).padStart(2));
-    if (dayOfWeek === saturday || i === last_date) {
+    if (dayOfWeek === saturday || i === lastDate) {
       rows.push(row.join(" "));
       row = [];
       dayOfWeek = 0;

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -14,15 +14,15 @@ const buildCalendarBody = (year, month) => {
   const saturday = 6;
   const firstDate = new Date(year, month - 1, 1);
   const lastDate = new Date(year, month, 0);
-  let datesPerWeek = Array(firstDate.getDay()).fill("  ");
+  let dateStringsPerRow = Array(firstDate.getDay()).fill("  ");
   const rows = [];
   [...Array(lastDate.getDate())]
     .map((_, i) => new Date(year, month - 1, i + 1))
     .forEach((date) => {
-      datesPerWeek.push(String(date.getDate()).padStart(2));
+      dateStringsPerRow.push(String(date.getDate()).padStart(2));
       if (date.getDay() === saturday || date.getDate() === lastDate.getDate()) {
-        rows.push(datesPerWeek.join(" "));
-        datesPerWeek = [];
+        rows.push(dateStringsPerRow.join(" "));
+        dateStringsPerRow = [];
       }
     });
   const totalRows = 6;

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -25,7 +25,7 @@ const buildCalendarBody = (year, month) => {
 
   const dayCountPerRow = 7;
   const rows = [];
-  while (dateStrings.length) {
+  while (dateStrings.length > 0) {
     const dateStringsPerRow = dateStrings.splice(0, dayCountPerRow);
     rows.push(dateStringsPerRow.join(" "));
   }

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -28,10 +28,8 @@ const arrangeDates = (year, month) => {
     }
   }
   const totalRows = 6;
-  if (rows.length < totalRows) {
-    rows.push("");
-  }
-  return rows;
+  const emptyRows = new Array(totalRows - rows.length).fill("");
+  return rows.concat(emptyRows);
 };
 
 if (import.meta.filename === process.argv[1]) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -34,12 +34,11 @@ const arrangeDates = (year, month) => {
 
 if (import.meta.filename === process.argv[1]) {
   const today = new Date();
-  const options = {
+  const params = minimist(process.argv.slice(2), {
     default: {
       y: today.getFullYear(),
       m: today.getMonth() + 1,
     },
-  };
-  const params = minimist(process.argv.slice(2), options);
+  });
   console.log(cal(params.y, params.m));
 }

--- a/02.calendar/package-lock.json
+++ b/02.calendar/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "minimist": "^1.2.8"
+      },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
         "eslint": "^9.9.0",
@@ -796,6 +799,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -10,5 +10,8 @@
     "globals": "^15.9.0",
     "prettier": "^3.3.3"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "minimist": "^1.2.8"
+  }
 }

--- a/02.calendar/test/cal-test.js
+++ b/02.calendar/test/cal-test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import * as assert from "node:assert";
-import { cal } from "../cal.js";
+import { buildCalendar } from "../cal.js";
 
 // 月が1桁
 test("2024_3", () => {
@@ -12,7 +12,7 @@ test("2024_3", () => {
 17 18 19 20 21 22 23
 24 25 26 27 28 29 30
 31`;
-  assert.strictEqual(cal(2024, 3), expected);
+  assert.strictEqual(buildCalendar(2024, 3), expected);
 });
 
 // 月が2桁、最終行が空行
@@ -25,7 +25,7 @@ test("2023_11", () => {
 19 20 21 22 23 24 25
 26 27 28 29 30
 `;
-  assert.strictEqual(cal(2023, 11), expected);
+  assert.strictEqual(buildCalendar(2023, 11), expected);
 });
 
 // 最終2行が空行
@@ -38,5 +38,5 @@ test("1970_2", () => {
 22 23 24 25 26 27 28
 
 `;
-  assert.strictEqual(cal(1970, 2), expected);
+  assert.strictEqual(buildCalendar(1970, 2), expected);
 });

--- a/02.calendar/test/cal-test.js
+++ b/02.calendar/test/cal-test.js
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import * as assert from "node:assert";
+import { cal } from "../cal.js";
+
+// 月が1桁
+test("2024_3", () => {
+  const expected = `      3月 2024
+日 月 火 水 木 金 土
+                1  2
+ 3  4  5  6  7  8  9
+10 11 12 13 14 15 16
+17 18 19 20 21 22 23
+24 25 26 27 28 29 30
+31`;
+  assert.strictEqual(cal(2024, 3), expected);
+});
+
+// 月が2桁、最終行が空行
+test("2023_11", () => {
+  const expected = `      11月 2023
+日 月 火 水 木 金 土
+          1  2  3  4
+ 5  6  7  8  9 10 11
+12 13 14 15 16 17 18
+19 20 21 22 23 24 25
+26 27 28 29 30
+`;
+  assert.strictEqual(cal(2023, 11), expected);
+});

--- a/02.calendar/test/cal-test.js
+++ b/02.calendar/test/cal-test.js
@@ -27,3 +27,16 @@ test("2023_11", () => {
 `;
   assert.strictEqual(cal(2023, 11), expected);
 });
+
+// 最終2行が空行
+test("1970_2", () => {
+  const expected = `      2月 1970
+日 月 火 水 木 金 土
+ 1  2  3  4  5  6  7
+ 8  9 10 11 12 13 14
+15 16 17 18 19 20 21
+22 23 24 25 26 27 28
+
+`;
+  assert.strictEqual(cal(1970, 2), expected);
+});

--- a/02.calendar/test/cal-test.js
+++ b/02.calendar/test/cal-test.js
@@ -1,9 +1,14 @@
-import { test } from "node:test";
+import { describe, it } from "node:test";
 import * as assert from "node:assert";
 import { buildCalendar } from "../cal.js";
 
-test("2024_3 calendar with no blank lines", () => {
-  const expected = `      3月 2024
+describe("given a year and month, buildCalendar returns the same calendar string as the macOS cal command", () => {
+  // macOSのcalコマンドではカレンダー全体の行数は常に8行
+  // 年月によって日付が並ぶ行の行数が4~6とブレがあるが、不足分は空行で埋められる仕様
+  // テストケース削減のためにこの空行の数の観点で同値分割した上でカレンダー全体の文字列をチェックする
+
+  it("calendar with no blank lines", () => {
+    const expected = `      3月 2024
 日 月 火 水 木 金 土
                 1  2
  3  4  5  6  7  8  9
@@ -11,11 +16,11 @@ test("2024_3 calendar with no blank lines", () => {
 17 18 19 20 21 22 23
 24 25 26 27 28 29 30
 31`;
-  assert.strictEqual(buildCalendar(2024, 3), expected);
-});
+    assert.strictEqual(buildCalendar(2024, 3), expected);
+  });
 
-test("2023_11 calendar with a blank line", () => {
-  const expected = `      11月 2023
+  it("calendar with a blank line", () => {
+    const expected = `      11月 2023
 日 月 火 水 木 金 土
           1  2  3  4
  5  6  7  8  9 10 11
@@ -23,11 +28,11 @@ test("2023_11 calendar with a blank line", () => {
 19 20 21 22 23 24 25
 26 27 28 29 30
 `;
-  assert.strictEqual(buildCalendar(2023, 11), expected);
-});
+    assert.strictEqual(buildCalendar(2023, 11), expected);
+  });
 
-test("1970_2 calendar with two blank lines", () => {
-  const expected = `      2月 1970
+  it("calendar with two blank lines", () => {
+    const expected = `      2月 1970
 日 月 火 水 木 金 土
  1  2  3  4  5  6  7
  8  9 10 11 12 13 14
@@ -35,5 +40,6 @@ test("1970_2 calendar with two blank lines", () => {
 22 23 24 25 26 27 28
 
 `;
-  assert.strictEqual(buildCalendar(1970, 2), expected);
+    assert.strictEqual(buildCalendar(1970, 2), expected);
+  });
 });

--- a/02.calendar/test/cal-test.js
+++ b/02.calendar/test/cal-test.js
@@ -2,8 +2,7 @@ import { test } from "node:test";
 import * as assert from "node:assert";
 import { buildCalendar } from "../cal.js";
 
-// 月が1桁
-test("2024_3", () => {
+test("2024_3 calendar with no blank lines", () => {
   const expected = `      3月 2024
 日 月 火 水 木 金 土
                 1  2
@@ -15,8 +14,7 @@ test("2024_3", () => {
   assert.strictEqual(buildCalendar(2024, 3), expected);
 });
 
-// 月が2桁、最終行が空行
-test("2023_11", () => {
+test("2023_11 calendar with a blank line", () => {
   const expected = `      11月 2023
 日 月 火 水 木 金 土
           1  2  3  4
@@ -28,8 +26,7 @@ test("2023_11", () => {
   assert.strictEqual(buildCalendar(2023, 11), expected);
 });
 
-// 最終2行が空行
-test("1970_2", () => {
+test("1970_2 calendar with two blank lines", () => {
   const expected = `      2月 1970
 日 月 火 水 木 金 土
  1  2  3  4  5  6  7


### PR DESCRIPTION
macOSのcalコマンドを模倣しました。

- `-y xx -m xx`でxx年xx月のカレンダーを表示
- `-m xx`で今年xx月のカレンダーを表示
- 指定しない場合は今年今月のカレンダーを表示
- 1970~2100年までは表示できる
- 空行を含めた行数をOSのcalコマンドと同じ8行にした
- 今日の日付の部分の色反転は未対応